### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,4 @@ group=com.enonic.app
 projectName=menu
 appName=com.enonic.app.menu
 xpVersion=8.0.0-B4
-version=2.0.1-SNAPSHOT
-
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bumps `version` in `gradle.properties` from `2.0.1-SNAPSHOT` to `3.0.0-SNAPSHOT` for the upcoming XP 8 major.
- Adds a `releaseBranch:` block to the `enonic-gradle.yml` workflow listing both `master` and `2.x`, so release-tools recognizes either branch as a release branch.
- The `2.x` maintenance branch was created (off the post-release SNAPSHOT commit `db7cf3b`) for the XP 7 line. A separate PR adds the matching `releaseBranch:` config to that branch's workflow.

## Test plan
- [ ] `./gradlew clean build` is green from master after merge