### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x` so release-tools recognizes pushes to the `2.x` maintenance branch as release-branch builds.
- The companion master PR bumps the version to `3.0.0-SNAPSHOT` and adds the same `releaseBranch:` block on master. The XP 7 maintenance line continues here on `2.x` at `2.0.1-SNAPSHOT` (`xpVersion=7.14.0`).

## Test plan
- [ ] After merge, a CI run on `2.x` is classified as a release branch by `enonic/release-tools/build-and-publish`